### PR TITLE
Fix list function for edge scenarios

### DIFF
--- a/text.go
+++ b/text.go
@@ -123,16 +123,26 @@ func Plural(amount int, text ...string) string {
 
 // List creates a list of the string entries with commas and an ending "and"
 func List(list []string) string {
-	var buf bytes.Buffer
-	for idx, entry := range list {
-		fmt.Fprint(&buf, entry)
+	switch len(list) {
+	case 1:
+		return list[0]
 
-		if idx < len(list)-2 {
-			fmt.Fprint(&buf, ", ")
-		} else if idx < len(list)-1 {
-			fmt.Fprint(&buf, ", and ")
+	case 2:
+		return fmt.Sprintf("%s and %s", list[0], list[1])
+
+	default:
+		var buf bytes.Buffer
+		for idx, entry := range list {
+			fmt.Fprint(&buf, entry)
+
+			if idx < len(list)-2 {
+				fmt.Fprint(&buf, ", ")
+
+			} else if idx < len(list)-1 {
+				fmt.Fprint(&buf, ", and ")
+			}
 		}
-	}
 
-	return buf.String()
+		return buf.String()
+	}
 }

--- a/text_test.go
+++ b/text_test.go
@@ -119,7 +119,22 @@ var _ = Describe("Generate random strings with fixed length", func() {
 	})
 
 	Context("Creating human readable lists", func() {
-		It("should create a human readable list of strings", func() {
+		It("should create a human readable list of no strings", func() {
+			Expect(List([]string{})).
+				To(BeEquivalentTo(""))
+		})
+
+		It("should create a human readable list of one strings", func() {
+			Expect(List([]string{"one"})).
+				To(BeEquivalentTo("one"))
+		})
+
+		It("should create a human readable list of two strings", func() {
+			Expect(List([]string{"one", "two"})).
+				To(BeEquivalentTo("one and two"))
+		})
+
+		It("should create a human readable list of multiple strings", func() {
 			Expect(List([]string{"one", "two", "three", "four"})).
 				To(BeEquivalentTo("one, two, three, and four"))
 		})


### PR DESCRIPTION
The list function did not return correct lists for two entries, because it
added an unnecessary comma.

Add check for special length in order to create the correct results.